### PR TITLE
Disable arc midpoint editing during simulation

### DIFF
--- a/public/petri-view.js
+++ b/public/petri-view.js
@@ -2834,6 +2834,7 @@ class PetriView extends HTMLElement {
         const i = Number(badge.dataset.arc);
         const a = this._model.arcs && this._model.arcs[i];
         if (!a) return;
+        if (this._simRunning) return;
 
         if (this._modeCan('canDeleteOnClick')) {
             this._model.arcs = (this._model.arcs || []).filter((_, j) => j !== i);


### PR DESCRIPTION
## Summary
- Add `_simRunning` guard to `_onBadgeClick` to prevent arc editing when play mode is active
- Prevents weight editing, inhibitor toggling, and arc deletion via midpoint badge clicks during simulation

## Test plan
- [ ] Start simulation (play mode), click an arc midpoint badge — no edit prompt should appear
- [ ] Stop simulation, click an arc midpoint badge — editing works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)