### PR TITLE
docs: fix stale seal-cid.js references to seal-cid.mjs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ test: test-js test-parity
 test-js:
 	@deno test public/petri-sim_test.ts
 
-# Cross-language CID parity: Go seal (internal/seal) vs JS seal (public/seal-cid.js)
+# Cross-language CID parity: Go seal (internal/seal) vs JS seal (public/seal-cid.mjs)
 # against the shared golden fixtures in parity/. Fails the build on any divergence.
 # parity_check.mjs runs under node or deno; node is used here for portability.
 test-parity:
-	@echo "Parity: Go seal vs JS seal-cid.js (parity/golden.json)..."
+	@echo "Parity: Go seal vs JS seal-cid.mjs (parity/golden.json)..."
 	@go test ./internal/seal/ -count=1
 	@node parity/parity_check.mjs
 

--- a/parity/parity_check.mjs
+++ b/parity/parity_check.mjs
@@ -1,6 +1,6 @@
 // parity_check.mjs — JS side of the JS/Go CID parity contract.
 //
-// Asserts that public/seal-cid.js (the same module the browser editor uses)
+// Asserts that public/seal-cid.mjs (the same module the browser editor uses)
 // reproduces every CID in parity/golden.json for the matching fixture. The Go
 // side checks the identical fixtures/golden in internal/seal/parity_test.go.
 // Green on both => the JS and Go CID pipelines agree byte-for-byte.


### PR DESCRIPTION
## What

The JS CID-parity module was renamed from `seal-cid.js` to `seal-cid.mjs`, but three comments still pointed at the old filename. The code already imports the correct `.mjs` file; this only updates the stale comments so they match reality.

- `Makefile:32`, `Makefile:36` — comment + echo text
- `parity/parity_check.mjs:3` — header comment

## Verification

The CID parity dual was confirmed green on both sides before and after the change (comment-only edit, no behavior change):

- Go: `internal/seal/parity_test.go` → `TestParityGolden` — 5/5 fixtures match
- JS: `parity/parity_check.mjs` → `public/seal-cid.mjs` — 5/5 fixtures match

https://claude.ai/code/session_01GMYoZcMqMvorYiKsvXAeTT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMYoZcMqMvorYiKsvXAeTT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and test configuration files to align file references across testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->