### PR TITLE
npm: package the public/ ES modules as pflow-xyz; stage the cdnjs submission

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,51 @@
+name: npm publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  id-token: write # npm provenance attestation
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify tag matches package.json version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::tag v$tag does not match package.json version $pkg"
+            exit 1
+          fi
+
+      - name: Verify every files entry exists
+        run: |
+          node -e '
+            const fs = require("fs");
+            const missing = require("./package.json").files
+              .filter(f => !f.includes("*"))
+              .filter(f => !fs.existsSync(f));
+            if (missing.length) {
+              console.error("missing from disk:", missing.join(", "));
+              process.exit(1);
+            }
+          '
+
+      - name: Show tarball contents
+        run: npm pack --dry-run
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Run JavaScript tests
         run: deno test public/petri-sim_test.ts
 
+      - name: Verify npm package
+        run: ./scripts/npm-pack-test.sh
+
       - name: Copy public assets for Go embed
         run: cp -r public internal/static/
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run clean test test-js test-parity test-publish publish
+.PHONY: all build run clean test test-js test-parity test-publish test-npm-pack publish
 
 # Build the webserver
 build:
@@ -25,12 +25,19 @@ clean:
 	@echo "Clean complete"
 
 # Run tests
-test: test-js test-parity test-parity-behavior test-publish
+test: test-js test-parity test-parity-behavior test-publish test-npm-pack
 	@go test ./...
 
 # Run JavaScript tests
 test-js:
 	@deno test public/petri-sim_test.ts public/petri-colors_test.ts
+
+# npm package verification: pack the tarball, extract it, assert the import
+# graph ships and site media doesn't, smoke-test the solver from the extracted
+# package, and resolve the exports map from a scratch install. Skips if npm is
+# not installed (same policy as the node edge in the parity tests).
+test-npm-pack:
+	@./scripts/npm-pack-test.sh
 
 # Publisher for cdn.stackdump.com (uses a temp blobs dir; touches no real state)
 test-publish:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "pflow-xyz",
+  "version": "1.21.0",
+  "description": "Dependency-free ES modules for Petri nets: mass-action ODE solver (Tsit5) with an interactive SVG plotter, discrete firing semantics, colored-net unfolding, and the <petri-view> editor web component.",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://pflow.xyz",
+  "repository": { "type": "git", "url": "git+https://github.com/pflow-xyz/pflow-xyz.git" },
+  "bugs": { "url": "https://github.com/pflow-xyz/pflow-xyz/issues" },
+  "keywords": ["petri-net", "ode-solver", "tsit5", "simulation", "state-machine", "workflow", "mass-action", "json-ld"],
+  "exports": {
+    ".": "./public/petri-solver.js",
+    "./petri-solver.js": "./public/petri-solver.js",
+    "./petri-sim.js": "./public/petri-sim.js",
+    "./petri-colors.js": "./public/petri-colors.js",
+    "./petri-view.js": "./public/petri-view.js",
+    "./petri-view.css": "./public/petri-view.css",
+    "./llms.txt": "./public/llms.txt",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": ["./public/petri-view.js", "./public/diagram-viewer.js"],
+  "files": [
+    "public/petri-solver.js",
+    "public/petri-sim.js",
+    "public/petri-colors.js",
+    "public/petri-view.js",
+    "public/petri-view.css",
+    "public/diagram-viewer.js",
+    "public/seal-cid.mjs",
+    "public/vendor/jsonld.bundle.mjs",
+    "public/schema",
+    "public/llms.txt",
+    "public/llms-full.txt",
+    "LICENSE",
+    "README.md"
+  ],
+  "publishConfig": { "access": "public", "provenance": true }
+}

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -54,21 +54,34 @@ Notes: `capacity` 0 or absent means unbounded. `initial`, `capacity`, and
 weight component means "this color is not involved". Set
 `"inhibitTransition": true` on an arc for an inhibitor.
 
-## Sandboxed environments (claude.ai artifacts, strict-CSP hosts)
+## Sandboxed environments (strict-CSP hosts)
 
-Some sandboxes only allow scripts from an allowlist of public CDNs, which
-blocks pflow.xyz. jsDelivr mirrors these modules and is broadly allowlisted;
-relative imports (petri-colors.js) resolve against whichever origin loaded
-the module, so either source is self-sufficient. Prefer a dynamic import
-with fallback so the same file works everywhere:
+**claude.ai artifacts cannot load these modules today.** Artifact CSP allows
+external scripts only from `cdnjs.cloudflare.com`; imports from pflow.xyz,
+jsDelivr, esm.sh, or unpkg are all refused there and fail with
+`Failed to fetch dynamically imported module`. Don't write a fallback loader
+for artifacts — it fails on every origin. Host the page elsewhere (any static
+host works; the modules are CORS-open). A cdnjs submission is staged; once
+accepted, `https://cdnjs.cloudflare.com/ajax/libs/pflow-xyz/<version>/petri-solver.js`
+will be the artifact-compatible URL — until then that URL 404s.
+
+Also: `file://` pages can't load ES modules at all (CORS blocks them), so
+"open the HTML file in a browser" is not enough for local use — serve it,
+e.g. `python3 -m http.server`.
+
+For *other* strict-CSP hosts that do allow common CDNs, jsDelivr mirrors the
+repo; relative imports (petri-colors.js) resolve against whichever origin
+loaded the module, so either source is self-sufficient:
 
 ```js
 const pf = await import("https://pflow.xyz/petri-solver.js")
-  .catch(() => import("https://cdn.jsdelivr.net/gh/pflow-xyz/pflow-xyz@main/public/petri-solver.js"));
+  .catch(() => import("https://cdn.jsdelivr.net/gh/pflow-xyz/pflow-xyz@v1.21.0/public/petri-solver.js"));
 ```
 
-Pin `@main` to a commit SHA for reproducible pages. (jsDelivr caches @main
-for ~12h, so it can lag the latest deploy.)
+Pin a release tag (as above) or commit SHA — `@main` is cached ~12h by
+jsDelivr, so it lags the latest deploy. Once the `pflow-xyz` npm package is
+published, npm-backed CDNs work too: `https://esm.sh/pflow-xyz@1.21.0` or
+`https://unpkg.com/pflow-xyz@1.21.0/public/petri-solver.js`.
 
 ## Minimal ad-hoc page: solve an ODE and plot it
 
@@ -76,7 +89,7 @@ for ~12h, so it can lag the latest deploy.)
 <div id="plot"></div>
 <script type="module">
   const pf = await import("https://pflow.xyz/petri-solver.js")
-    .catch(() => import("https://cdn.jsdelivr.net/gh/pflow-xyz/pflow-xyz@main/public/petri-solver.js"));
+    .catch(() => import("https://cdn.jsdelivr.net/gh/pflow-xyz/pflow-xyz@v1.21.0/public/petri-solver.js"));
 
   const model = { /* JSON-LD model as above */ };
   const net = pf.fromJSON(model);

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -42,9 +42,16 @@ weight component means "this color is not involved".
 
 ## Optional
 
-- [Mirror via jsDelivr](https://cdn.jsdelivr.net/gh/pflow-xyz/pflow-xyz@main/public/petri-solver.js):
-  same modules on a CDN that sandboxed environments (e.g. claude.ai
-  artifacts, whose CSP blocks pflow.xyz) allow; substitute `@main` with a
-  commit SHA for reproducible pages. Recommended pattern — dynamic import
-  with fallback:
-  `await import('https://pflow.xyz/petri-solver.js').catch(() => import('https://cdn.jsdelivr.net/gh/pflow-xyz/pflow-xyz@main/public/petri-solver.js'))`
+- CDN mirrors for strict-CSP hosts that block pflow.xyz — pin a tag, `@main`
+  is cached ~12h by jsDelivr:
+  - [jsDelivr](https://cdn.jsdelivr.net/gh/pflow-xyz/pflow-xyz@v1.21.0/public/petri-solver.js)
+  - npm-backed (after `pflow-xyz` is on npm): `https://esm.sh/pflow-xyz@1.21.0`
+    or `https://unpkg.com/pflow-xyz@1.21.0/public/petri-solver.js`
+  - cdnjs (pending acceptance — placeholder, 404s until then):
+    `https://cdnjs.cloudflare.com/ajax/libs/pflow-xyz/<version>/petri-solver.js`
+- **claude.ai artifacts cannot load these modules today.** Their CSP allows
+  scripts only from `cdnjs.cloudflare.com`; pflow.xyz, jsDelivr, esm.sh, and
+  unpkg are all refused (`Failed to fetch dynamically imported module`). Do
+  not emit an import-with-fallback loader for artifacts — host the page
+  elsewhere instead. Also note `file://` pages can't load ES modules at all;
+  open local pages via `python3 -m http.server`.

--- a/scripts/cdnjs/README.md
+++ b/scripts/cdnjs/README.md
@@ -1,0 +1,53 @@
+# cdnjs submission (staged, not yet filed)
+
+`pflow-xyz.json` is the package definition for
+[cdnjs/packages](https://github.com/cdnjs/packages). It is staged here because
+cdnjs's acceptance bar (from their CONTRIBUTING.md: **800+ npm downloads/month
+or ~200 GitHub stars**, at maintainer discretion) is not met yet. File the PR
+once it is.
+
+Why cdnjs at all: `cdnjs.cloudflare.com` is the only external script origin
+allowed inside claude.ai artifacts, so acceptance is what makes the solver
+importable there.
+
+## How to file
+
+1. Fork `cdnjs/packages`, branch.
+2. Copy `pflow-xyz.json` to `packages/p/pflow-xyz.json`.
+3. Run their checker: `npm test` in the fork validates the JSON against the schema.
+4. Commit message: `Add pflow-xyz w/ npm auto-update` (matches `autoupdate.source`).
+5. Open the PR; a cdnjs maintainer reviews popularity and merges.
+
+## Decisions already made
+
+- **`autoupdate.source: npm`** — cdnjs mirrors each new `pflow-xyz` npm release
+  automatically. The npm tarball ships exactly the runtime import graph and no
+  site media, so the `fileMap` globs can't pick up junk.
+- **`.mjs` is on the cdnjs extension whitelist** (checked against
+  `https://api.cdnjs.com/whitelist` 2026-08-01: `js, mjs, ts, wasm, map, json,
+  css, …`), so `seal-cid.mjs` and `vendor/jsonld.bundle.mjs` copy fine and
+  `petri-view.js`'s full import chain works from cdnjs. No renames needed.
+- **Minification left enabled** (no `optimization` key). cdnjs generates
+  `.min.js` siblings alongside the originals; harmless. The **canonical
+  documented URL is the unminified file** — the modules import each other by
+  their unminified names (`./petri-colors.js`), so pointing docs at the
+  originals keeps the whole loaded graph consistent, and the files are small
+  enough (34KB solver) that minification buys little.
+- **`filename: petri-solver.js`** — the default file cdnjs features. The
+  solver is the artifact-sandbox use case; the editor component is secondary.
+
+## Consumer URL shape (post-acceptance)
+
+cdnjs serves no `latest` alias; every URL is version-pinned:
+
+```
+https://cdnjs.cloudflare.com/ajax/libs/pflow-xyz/<version>/petri-solver.js
+```
+
+Relative imports (`./petri-colors.js`, `./seal-cid.mjs`,
+`./vendor/jsonld.bundle.mjs`) resolve against that same directory, so a single
+import of `petri-solver.js` or `petri-view.js` pulls the rest of the graph
+from cdnjs automatically.
+
+After acceptance, fill in the placeholder URLs in `public/llms.txt` and
+`public/llms-full.txt`.

--- a/scripts/cdnjs/pflow-xyz.json
+++ b/scripts/cdnjs/pflow-xyz.json
@@ -1,0 +1,18 @@
+{
+  "name": "pflow-xyz",
+  "description": "Dependency-free ES modules for Petri nets: mass-action ODE solver (Tsit5) with an interactive SVG plotter, discrete firing semantics, and the <petri-view> editor web component",
+  "license": "MIT",
+  "filename": "petri-solver.js",
+  "homepage": "https://pflow.xyz",
+  "repository": { "type": "git", "url": "git+https://github.com/pflow-xyz/pflow-xyz.git" },
+  "keywords": ["petri-net", "ode-solver", "simulation", "state-machine", "workflow"],
+  "autoupdate": {
+    "source": "npm",
+    "target": "pflow-xyz",
+    "fileMap": [{
+      "basePath": "public",
+      "files": ["petri-*.js", "petri-view.css", "diagram-viewer.js", "*.mjs", "vendor/*.mjs"]
+    }]
+  },
+  "authors": [{ "name": "Stackdump.com LLC", "url": "https://stackdump.com" }]
+}

--- a/scripts/npm-pack-test.sh
+++ b/scripts/npm-pack-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Verify the npm package as it would actually ship:
+#   1. npm pack, extract, assert the import graph is complete and site media absent
+#   2. run scripts/npm-smoke.mjs against the extracted package
+#   3. install the tarball into a scratch package and resolve the exports map
+# Skips (exit 0) when npm/node are not installed, mirroring the parity tests.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v npm >/dev/null || ! command -v node >/dev/null; then
+  echo "npm-pack-test: npm/node not found, skipping"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+tarball="$(npm pack --pack-destination "$tmp" --silent | tail -1)"
+tar -xzf "$tmp/$tarball" -C "$tmp"
+pkg="$tmp/package"
+
+# Every file in the runtime import graph must ship, or imports 404 at runtime.
+required=(
+  public/petri-solver.js
+  public/petri-sim.js
+  public/petri-colors.js
+  public/petri-view.js
+  public/petri-view.css
+  public/diagram-viewer.js
+  public/seal-cid.mjs
+  public/vendor/jsonld.bundle.mjs
+)
+for f in "${required[@]}"; do
+  [ -f "$pkg/$f" ] || { echo "FAIL: $f missing from tarball"; exit 1; }
+done
+
+# Site media must NOT ship.
+banned=$(cd "$pkg" && find . -name '*.png' -o -name '*.webm' -o -name '*.mp4' -o -name '*.ico')
+if [ -n "$banned" ]; then
+  echo "FAIL: media leaked into tarball:"
+  echo "$banned"
+  exit 1
+fi
+
+node scripts/npm-smoke.mjs "$pkg"
+
+# Prove the exports map resolves from a consumer's point of view.
+scratch="$tmp/scratch"
+mkdir -p "$scratch"
+( cd "$scratch" \
+  && npm init -y --silent >/dev/null \
+  && npm install --silent --no-audit --no-fund "$tmp/$tarball" >/dev/null \
+  && node --input-type=module -e '
+    const solver = await import("pflow-xyz");
+    const sim = await import("pflow-xyz/petri-sim.js");
+    if (typeof solver.solve !== "function") throw new Error("pflow-xyz: solve export missing");
+    if (typeof sim.fire !== "function") throw new Error("pflow-xyz/petri-sim.js: fire export missing");
+    console.log("ok: exports map resolves (pflow-xyz, pflow-xyz/petri-sim.js)");
+  ' )

--- a/scripts/npm-smoke.mjs
+++ b/scripts/npm-smoke.mjs
@@ -1,0 +1,72 @@
+// Smoke test for the npm package: run against an EXTRACTED tarball, not the
+// repo tree, so it exercises exactly the files that ship.
+//
+//   node scripts/npm-smoke.mjs <extracted-package-dir>
+//
+// Solves Lotka-Volterra and asserts the conserved quantity
+//   V = k_death*ln(R) - k_pred*R + k_birth*ln(F) - k_pred*F
+// drifts < 1e-9 across [0, 30]. The solver currently holds ~2e-11, so this
+// guards real integration regressions, not just "it ran".
+
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+
+const pkgDir = process.argv[2];
+if (!pkgDir) {
+  console.error("usage: node scripts/npm-smoke.mjs <extracted-package-dir>");
+  process.exit(2);
+}
+
+const pf = await import(pathToFileURL(resolve(pkgDir, "public/petri-solver.js")));
+
+const K_BIRTH = 1.1, K_PRED = 0.4, K_DEATH = 0.4;
+
+const model = {
+  "@context": "https://pflow.xyz/schema",
+  "@type": "PetriNet",
+  "@version": "1.1",
+  token: ["https://pflow.xyz/tokens/black"],
+  places: {
+    rabbits: { "@type": "Place", initial: [10], capacity: [0], x: 60, y: 60 },
+    foxes: { "@type": "Place", initial: [5], capacity: [0], x: 260, y: 60 },
+  },
+  transitions: {
+    birth: { "@type": "Transition", x: 60, y: 160 },
+    predation: { "@type": "Transition", x: 160, y: 160 },
+    death: { "@type": "Transition", x: 260, y: 160 },
+  },
+  arcs: [
+    { "@type": "Arrow", source: "rabbits", target: "birth", weight: [1] },
+    { "@type": "Arrow", source: "birth", target: "rabbits", weight: [2] },
+    { "@type": "Arrow", source: "rabbits", target: "predation", weight: [1] },
+    { "@type": "Arrow", source: "foxes", target: "predation", weight: [1] },
+    { "@type": "Arrow", source: "predation", target: "foxes", weight: [2] },
+    { "@type": "Arrow", source: "foxes", target: "death", weight: [1] },
+  ],
+};
+
+const net = pf.fromJSON(model);
+const prob = new pf.ODEProblem(net, pf.setState(net), [0, 30],
+  pf.setRates(net, { birth: K_BIRTH, predation: K_PRED, death: K_DEATH }));
+const sol = pf.solve(prob, pf.Tsit5(),
+  { dt: 0.01, abstol: 1e-6, reltol: 1e-3, adaptive: true });
+
+const tEnd = sol.t[sol.t.length - 1];
+if (Math.abs(tEnd - 30) > 1e-12) {
+  console.error(`FAIL: integration stopped at t=${tEnd}, expected 30 (maxiters hit?)`);
+  process.exit(1);
+}
+
+const R = sol.getVariable("rabbits");
+const F = sol.getVariable("foxes");
+const V = (r, f) => K_DEATH * Math.log(r) - K_PRED * r + K_BIRTH * Math.log(f) - K_PRED * f;
+const v0 = V(R[0], F[0]);
+let drift = 0;
+for (let i = 1; i < R.length; i++) drift = Math.max(drift, Math.abs(V(R[i], F[i]) - v0));
+
+if (!(drift < 1e-9)) {
+  console.error(`FAIL: LV invariant drift ${drift} >= 1e-9 over ${R.length} steps`);
+  process.exit(1);
+}
+
+console.log(`ok: t reached ${tEnd}, ${R.length} steps, LV invariant drift ${drift.toExponential(2)} < 1e-9`);


### PR DESCRIPTION
Repackages the existing browser ES modules in `public/` as the `pflow-xyz` npm package — no build step, no restructuring, no runtime deps — so cdnjs (the only script origin claude.ai artifacts allow) can auto-update from npm once the popularity bar is met.

- `package.json` with an exports map over the entry modules; tarball ships exactly the runtime import graph + docs (14 files, 146 kB packed), no site media
- `npm-publish.yml`: publish on `v*.*.*` tag with `--provenance`, guarded by tag↔version and files-exist checks
- `make test-npm-pack` (in `make test` + CI): pack → extract → graph/media assertions → Lotka-Volterra smoke test from the extracted package (invariant drift 2e-11 < 1e-9) → exports-map resolution from a scratch install
- staged cdnjs submission under `scripts/cdnjs/` (`.mjs` is on the cdnjs whitelist, full chain mirrors)
- `llms.txt`/`llms-full.txt`: correct the false claim that jsDelivr works in claude.ai artifacts; pin CDN URLs to v1.21.0

Deno, Bazel, and `make test` verified unchanged with the root `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added npm package publishing with version validation and provenance support.
  * Added public package exports for solvers, simulations, visualizations, styles, and usage guidance.
  * Added CDN distribution configuration and hosting guidance.

* **Documentation**
  * Clarified browser restrictions, CDN usage, version pinning, and local HTTP serving requirements.

* **Tests**
  * Added package validation and smoke tests covering tarball contents, exports, integration results, and numerical accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->